### PR TITLE
fix treatment of processed commit

### DIFF
--- a/bin/merge-by-path.sh
+++ b/bin/merge-by-path.sh
@@ -1,4 +1,18 @@
+#!/bin/bash
+
+control_c()
+# run if user hits control-c
+{
+  echo -en "\n*** Ouch! Exiting ***\n"
+  exit $?
+}
+
+# trap keyboard interrupt (control-c)
+#trap control_c SIGINT
+
+
 CURRENT_HASHES=/tmp/diff.hash
+
 PROCESSED_HASHES=/tmp/diff.processed.hash
 
 # save current hashes
@@ -11,14 +25,14 @@ declare LINES=($(cat $CURRENT_HASHES | grep -vf $PROCESSED_HASHES))
 for l in ${LINES[@]}
 do
     # save into processed hashes
-    echo $l >> $PROCESSED_HASHES
+    #echo $l >> $PROCESSED_HASHES
     git show --name-only $l
     read -p "Process ? [yn] " -n 1
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         echo "Skipped"
     else
         echo 'passed'
-        git cherry-pick -n --keep-redundant-commits --allow-empty $l
+        git cherry-pick $l
         errcode=$?
         if [ $errcode -eq 0 ]; then
             echo $l
@@ -26,5 +40,8 @@ do
             echo "failed $l"
             ~/bin/resolve-theirs.sh
         fi
+    fi
+    if [[ $REPLY =~ ^[YyNn]$ ]]; then
+    echo $l >> $PROCESSED_HASHES
     fi
 done


### PR DESCRIPTION
If user hits y,Y,N,n the hash is added to processed list, otherwise - skipped so one can go back to that hash once again
