### PR TITLE
feat(pi-job): decision access via markdown --slice + Channels

### DIFF
--- a/dot_agents/skills/pi-job/SKILL.md
+++ b/dot_agents/skills/pi-job/SKILL.md
@@ -42,9 +42,32 @@ Start the slice with `start --slice-only --model <orchestrator>` when needed.
 
 ## Reads (do not open the store)
 
-- `status`, `plan`, `show`, `show --slice KEY`, `instruction [--current]`
-- Use `show --slice KEY` when you need that slice's goal, notes, steps, or repo_work
+- `status`, `plan`, `markdown [--slice KEY]`, `show`, `show --slice KEY`, `instruction [--current]`
+- Subagent-owned steps: run `markdown --slice KEY` first to load binding `## Decisions` plus that slice
+- Use `show --slice KEY` for sibling-step evidence after decisions are loaded
 - Do not dump or browse the whole task document into context
+
+## Channels
+
+Hard rules for which write API to use:
+
+- **DECISION (`add-decision`)** = product, scope, architecture, or policy agreement that later sessions must honor without re-grilling.
+  Must still be true if the PR never merged.
+  Not a journal.
+- **STEP NOTE (`finish --note`)** = evidence that THIS step happened or failed: commands, e2e, scan findings, skip reasons.
+- **SLICE NOTE** = cross-step narrative; prefer `finish --slice-only`, not `add-decision`.
+- **PLAN FILE** (`<task-stem>.plans/<slice-key>.md`) = constraint-and-behaviour contract.
+- **PLAN NOTE (`set-plan-note`)** = destination / high-level map, not a progress log.
+- **PR / REPO (`add-pr`, `set-worktree`)** = delivery lifecycle; sync verify evidence stays in `finish --note`.
+
+Anti-patterns (do not use `add-decision` for these):
+
+- PR merge/deploy status (`PR #3420 MERGED + deployed`)
+- e2e or verify results (`e2e passed for assetUrl`)
+- progress markers (`RESOLVED: folded mapping into SHEMED-2329`)
+
+Good `add-decision`: scope agreements like "assets resolve via ProgrammeDefinition.defaultPartnerId; no static maps".
+Good `finish --note`: "Ran graphius e2e on dev-uk; assetUrl returns CDN path".
 
 ## Writes (mutation commands only)
 
@@ -56,7 +79,8 @@ Start the slice with `start --slice-only --model <orchestrator>` when needed.
 
 Put slice plans in `<task-stem>.plans/<slice-key>.md`, not in endless notes.
 Those files are succinct constraint-and-behaviour contracts.
-Persist durable agreements with `add-decision` (and/or the grilled plan), not only in chat.
+Persist product/scope/architecture/policy agreements with `add-decision` (and/or the grilled plan), not only in chat.
+Step evidence belongs in `finish --note`, not `add-decision`.
 Token smell: if a step needs a huge dump to proceed, shrink the contract or the slice.
 Full wording lives in `plan_and_grill_guardrail` in `~/.local/share/pi-job-harness/profile.yaml` (chezmoi source: `dot_local/share/pi-job-harness/profile.yaml`).
 `validate` / `status` warn on oversized notes (~2000 chars) and large task files (~100KB); they do not refuse `finish`.
@@ -79,7 +103,7 @@ Map wayfinder's constructs onto pi-job:
 | Wayfinder | pi-job |
 |---|---|
 | the map | this task file (destination = `plan.note`) |
-| decisions so far | `decisions` via `add-decision` |
+| decisions so far | `decisions` via `add-decision` (product/scope only; not PR/e2e/deploy chatter) |
 | research / prototype / decision ticket | a slice: `add-slice --kind research` / `spike` / `fog` |
 | implementation ticket | `add-slice --kind implement` |
 | blocking relationship | `--depends-on` |

--- a/dot_local/share/pi-job-harness/README.md
+++ b/dot_local/share/pi-job-harness/README.md
@@ -46,7 +46,7 @@ Given a YAML task file and package-local `profile.yaml`, it can:
 - `init` - initialize `task.orchestration` and set the cursor; optionally seed the first slice from a slice kind template
 - `add-slice` / `remove-slice` - add or remove ordered slices with steps from the profile template
 - `add-step` - append a step to a slice
-- `set-project` / `set-context` / `set-plan-note` / `add-decision` / `set-slice` / `block-slice` / `unblock-slice` / `acknowledge-edit` - write task metadata and durable decisions without hand-editing the store
+- `set-project` / `set-context` / `set-plan-note` / `add-decision` / `set-slice` / `block-slice` / `unblock-slice` / `acknowledge-edit` - write task metadata and product/scope decisions without hand-editing the store
 - `status` / `next` / `plan` - report where the work is and what slices/steps remain
   (`status` also reports `Structure: ok` or a non-fatal `Structure: invalid` line from slice template lint; warns on oversized notes / large files)
 - `show` / `show --slice KEY` / `show --full` / `show --short` - tree view (compact by default), optional models, collapsed consecutive done names, or a slice-local detail view (goal, notes, steps, repo_work)
@@ -181,11 +181,46 @@ They appear in `instruction` and `plan` for orchestrator self-check.
   It does not spawn agents.
   The orchestrator chooses models and launches subagents.
 - Session todos should track the slice/step plan from `plan`, not a separate profile phase list.
-- Prefer small context: `status` / `show --slice` / `instruction` over loading the whole task file.
+- Prefer small context: `status` / `show --slice` / `markdown --slice` / `instruction` over loading the whole task file.
   Token smell: if a step needs a huge dump, shrink the contract or the slice.
 - Sibling slice plans are succinct constraint-and-behaviour contracts (intent, behaviour, constraints, verification).
-  Persist durable agreements with `add-decision` (and/or the grilled plan), not only in chat.
+  Persist product/scope/architecture/policy agreements with `add-decision` (and/or the grilled plan), not only in chat.
+  Step evidence belongs in `finish --note`, not `add-decision`.
 - Developer experience and agent experience share the same constructs: clear names, modular boundaries, and machine-readable contracts help both.
+
+## Channels
+
+Hard rules for which write API to use (same contract in profile packets, CLI help, and skill):
+
+- **DECISION (`add-decision`)** = product, scope, architecture, or policy agreement that later sessions must honor without re-grilling.
+  Must still be true if the PR never merged.
+  Prefer one sentence + rationale.
+  Not a journal.
+- **STEP NOTE (`finish --note`)** = evidence that THIS step happened or failed: commands, e2e results, scan findings, "gap recorded", skip reasons.
+- **SLICE NOTE** = cross-step narrative for the slice (blocker story, handoff).
+  Prefer `finish --slice-only`; not `add-decision`.
+- **PLAN FILE (`*.plans/<slice-key>.md`)** = constraint-and-behaviour contract.
+  Long prose lives here.
+- **PLAN NOTE (`set-plan-note`)** = destination / high-level map.
+  Not a progress log.
+- **PR / REPO (`add-pr`, `set-worktree`)** = delivery lifecycle.
+  Sync uses `finish --note` for verify evidence - keep it there.
+
+**Good `add-decision`**
+
+- UK ConfirmMedication assets resolve via ProgrammeDefinition.defaultPartnerId; no static Graphius maps.
+- Ship with temporary US CDN assets; UK-native assets blocked on uk-treatment-assets-commission before prod.
+
+**Bad `add-decision` (use `finish --note` / `add-pr` instead)**
+
+- PR #3420 MERGED + deployed to dev-uk.
+- e2e passed for assetUrl on ConfirmMedication.
+- RESOLVED: folded mapping into SHEMED-2329.
+
+**Good `finish --note`**
+
+- Ran graphius e2e on dev-uk; ConfirmMedication assetUrl returns CDN path; PI hold path verified.
+- `gh pr view` shows #3420 merged; advanced past wait-for-feedback.
 
 ## How an agent should know about it
 
@@ -355,7 +390,7 @@ These commands write task metadata and durable state without editing the YAML by
 
 - `pi-job --task <t> set-project --key K --name N --route R --context C` - merge into `task.project` (at least one flag required).
 - `pi-job --task <t> set-context --context TEXT` or `--file PATH` - replace `task.context`.
-- `pi-job --task <t> add-decision --date YYYY-MM-DD --note RATIONALE --source ORIGIN` - append a decision record (date defaults to today UTC; source defaults to `pi-job add-decision`).
+- `pi-job --task <t> add-decision --date YYYY-MM-DD --note RATIONALE --source ORIGIN` - append a product/scope decision (not step evidence; use `finish --note`; date defaults to today UTC; source defaults to `pi-job add-decision`).
 - `pi-job --task <t> set-plan-note --note TEXT` - set `task.plan.note`.
 - `pi-job --task <t> acknowledge-edit --reason R` - refresh `orchestration.content_digest` after a legitimate hand-edit and record a decision (YAML only).
 - `pi-job --task <t> set-slice --key K [--title T] [--goal G]` - update slice metadata (at least one of `--title` or `--goal` required; YAML only; refuses `done`/`skipped` slices).
@@ -486,7 +521,9 @@ See `projects/pi-agent-job-harness/workflow.md` in the weight-loss repo for the 
   Default slice order follows `plan.slices`.
   `--chronological` sorts slices by the earliest non-empty `execution.started` or `execution.ended` on the slice or any step/final_step (no-timestamp slices after; plan order tie-break).
 - Subagent instruction packets treat the emitted packet as sufficient context; they do not order inspecting the task store directly or opening full `profile.yaml`.
-  For sibling-step evidence within the current slice, the subagent prompt points at `pi-job --task <t> show --slice <key>`.
+  Subagents must run `pi-job --task <t> markdown --slice <key>` first to load binding `## Decisions` plus that slice.
+  For sibling-step evidence after decisions are loaded, the subagent prompt points at `pi-job --task <t> show --slice <key>`.
+  Orchestrators dispatch subagents with the markdown --slice command; they do not paste a decisions dump.
 
 The setup slice's `select-toolbelt` step picks aids suited to the task's slice kinds; `plan-slices` produces them.
 The catalog lives in `profile.yaml` under `toolbelt`.
@@ -508,7 +545,7 @@ The map is the task file itself: `decisions` and slices, readable by any later s
 - `pi-job --task <t> wayfinder-context` - print the map reconstructed from the task file at the slice level (no step noise): the `DESTINATION` (`plan.note`), recorded `DECISIONS`, `IN PROGRESS / DONE` slices, the `FRONTIER` (planned slices whose dependencies are satisfied), and the `FOG` (planned slices still blocked, with their unmet dependencies).
   Read-only; reuses the same `is_actionable` logic as `next`.
 - The `wayfinder` step drives the wayfinder skill (installed separately), using this task file as its issue tracker; the pi-job skill's Wayfinder section holds the map-to-task-file mapping.
-  It loads the map with `wayfinder-context`, spawns as many subagents as needed to resolve unknowns (research the world, prototype to see, grill the user), records each resolution with `add-decision`, and grows the plan with `add-slice`.
+  It loads the map with `wayfinder-context`, spawns as many subagents as needed to resolve unknowns (research the world, prototype to see, grill the user), records scope/architecture resolutions with `add-decision` (not PR/e2e/deploy chatter), and grows the plan with `add-slice`.
   It creates `fog` slices for areas still too foggy or decidable only after other work, and implement/research/spike slices for work now clear.
 - A `fog` slice (`clarify-scope → wayfinder → plan-slices`) is a deferred decision-branch, scheduled by `depends_on` so it is charted only once its prerequisites land.
   Its `wayfinder` step recurses, so charting one area can spawn further fog slices for its sub-fog.
@@ -646,7 +683,7 @@ Models use strict types and reject unknown fields.
 | `project` | object | Stable project key, name, workflow route, and project context. |
 | `context` | string | Free-form background required before acting. |
 | `orchestration` | object or null | Saved cursor, persisted execution policy, and artifacts. |
-| `decisions[]` | decision | Date, durable rationale, and source for a decision. |
+| `decisions[]` | decision | Date, product/scope rationale, and source for a binding decision (not step evidence). |
 | `plan.note` | string | High-level plan context. |
 | `plan.slices[]` | slice | Ordered atomic delivery units. |
 | `slice.key` | string | Stable identity used by dependencies and the cursor. |

--- a/dot_local/share/pi-job-harness/bin/executable_pi-job
+++ b/dot_local/share/pi-job-harness/bin/executable_pi-job
@@ -95,12 +95,13 @@ class StepDocument(StrictDocument):
 
 
 class DecisionDocument(StrictDocument):
-    """A durable decision made while executing a task."""
+    """Product/scope decision that later sessions must honor without re-grilling."""
 
     date: str = Field(description="Decision date, normally formatted as YYYY-MM-DD.")
     note: str = Field(
         description=(
-            "Decision and enough rationale to understand it later. "
+            "Product, scope, architecture, or policy agreement - not step evidence "
+            "(use finish --note for e2e, PR, deploy, or progress). "
             "Prefer Markdown; `pi-job markdown` renders it as a blockquote."
         )
     )
@@ -244,7 +245,10 @@ class TaskDocument(StrictDocument):
     project: ProjectDocument = Field(default_factory=ProjectDocument, description="Owning project metadata.")
     context: str = Field(default="", description="Free-form background required before acting on the task.")
     orchestration: OrchestrationDocument | None = Field(default=None, description="Cursor and policy state after initialization.")
-    decisions: list[DecisionDocument] = Field(default_factory=list, description="Durable decisions in chronological order.")
+    decisions: list[DecisionDocument] = Field(
+        default_factory=list,
+        description="Product/scope decisions in chronological order - not step evidence (use finish --note).",
+    )
     plan: PlanDocument = Field(default_factory=PlanDocument, description="Ordered slice and step plan.")
 
     @model_validator(mode="after")
@@ -359,7 +363,10 @@ class BootstrapDocument(StrictDocument):
     project: ProjectDocument = Field(default_factory=ProjectDocument, description="Owning project metadata.")
     context: str = Field(default="", description="Free-form background required before acting on the task.")
     plan_note: str = Field(default="", description="High-level plan context.")
-    decisions: list[DecisionDocument] = Field(default_factory=list, description="Durable decisions in chronological order.")
+    decisions: list[DecisionDocument] = Field(
+        default_factory=list,
+        description="Product/scope decisions in chronological order - not step evidence (use finish --note).",
+    )
     slices: list[BootstrapSliceDocument] = Field(default_factory=list, description="Ordered task slices declared by the user.")
 
     @model_validator(mode="after")
@@ -6330,16 +6337,20 @@ def main() -> None:
     start.add_argument("--slice-only", action="store_true", help="target the current slice instead of its current step")
     start.set_defaults(fn=cmd_start)
 
-    finish = sub.add_parser("finish", help="record end time and mark the current step or selected slice done/skipped")
+    finish = sub.add_parser(
+        "finish",
+        help="record end time and mark the current step or selected slice done/skipped",
+        description="record end time and mark the current step or selected slice done/skipped",
+    )
     finish.add_argument("--model", help="model ID; required only for an atomic skip that was not started")
     finish.add_argument("--slice", help="explicit slice key; without --step this targets the slice itself")
     finish.add_argument("--step", help="explicit step key (uses the current slice unless --slice is supplied)")
     finish.add_argument("--slice-only", action="store_true", help="target the current slice instead of its current step")
     finish.add_argument(
         "--note",
-        help="completion evidence as Markdown (preferred); rendered formatted in "
-        "`pi-job markdown`; omitted preserves the existing note; when supplied "
-        "appends with a blank line; --replace overwrites instead",
+        help="append completion/evidence for this step (not product decisions; use add-decision); "
+        "Markdown preferred; rendered formatted in `pi-job markdown`; omitted preserves the "
+        "existing note; when supplied appends with a blank line; --replace overwrites instead",
     )
     finish.add_argument(
         "--replace",
@@ -6481,7 +6492,11 @@ def main() -> None:
     set_context.add_argument("--file", dest="file_path", type=Path, help="read context from a file")
     set_context.set_defaults(fn=cmd_set_context)
 
-    add_decision = sub.add_parser("add-decision", help="append a durable decision record")
+    add_decision = sub.add_parser(
+        "add-decision",
+        help="append a product/scope decision (not step evidence; use finish --note)",
+        description="append a product/scope decision (not step evidence; use finish --note)",
+    )
     add_decision.add_argument("--date", default="", help="decision date (default: today UTC)")
     add_decision.add_argument(
         "--note",

--- a/dot_local/share/pi-job-harness/profile.yaml
+++ b/dot_local/share/pi-job-harness/profile.yaml
@@ -126,8 +126,9 @@ plan_and_grill_guardrail: &plan_and_grill_guidance |-
       (pi-job store owns those).
       DX and agent experience share the same constructs: clear names and short contracts
       help the next human and the next agent equally - write the plan for both.
-      Persist durable agreements with `pi-job add-decision` (and/or the grilled plan);
-      do not leave load-bearing agreements only in chat.
+      Persist product/scope/architecture/policy agreements with `pi-job add-decision`
+      (and/or the grilled plan); do not leave load-bearing scope choices only in chat.
+      Step evidence belongs in `finish --note`, not `add-decision`.
       Token smell: if the plan needs a huge dump to be usable, shrink the slice or the
       contract - do not compensate by loading more of the task store into context.
       Naming: beside the task file, directory `<task-stem>.plans/`, file
@@ -142,8 +143,9 @@ plan_and_grill_guardrail: &plan_and_grill_guidance |-
       If grilling surfaces a real gap, revise the plan FILE (not the
       task-file note), grill again, only mark grill-plan done once the plan survives
       - this is a loop, not a one-shot rubber stamp.
-      After grill survives, capture any durable choice that should outlive the session
+      After grill survives, capture product/scope choices that should outlive the session
       with `pi-job add-decision` (date/note/source), not only in chat.
+      Do not use add-decision for PR, deploy, e2e, or progress chatter.
   Mark both done only once the plan has survived grilling; advance refuses to pass an
   incomplete step, so edit-code-style steps stay unreachable until both are done.
   Distinct from the setup slice's `grill` step (overall scope before implement slices
@@ -170,8 +172,21 @@ instruction_packets:
     - Give the slice a bounded goal, the appropriate kind, and dependencies; do not bury actionable follow-up work only in notes.
   task_record_discipline: |-
     The task record is machine-owned; do not open or edit the task store directly.
-    Reads: pi-job --task {task_file} status | plan | show [--slice {slice_key}] | instruction [--current].
+    Reads: pi-job --task {task_file} status | plan | markdown [--slice {slice_key}] | show [--slice {slice_key}] | instruction [--current].
     Writes: pi-job mutation commands (start, finish [--replace], advance, add-slice, add-step, set-slice, block-slice, unblock-slice, set-project, set-context, add-decision, set-plan-note, remove-slice, set-worktree, add-pr, acknowledge-edit); see pi-job --help for the rest.
+    Channels (which write for which fact):
+    DECISION (add-decision) = product, scope, architecture, or policy agreement that
+      later sessions must honor without re-grilling. Must still be true if the PR
+      never merged. Prefer one sentence + rationale. Not a journal.
+    STEP NOTE (finish --note) = evidence that THIS step happened or failed:
+      commands, e2e results, scan findings, "gap recorded", skip reasons.
+    SLICE NOTE = cross-step narrative for the slice (blocker story, handoff).
+      Prefer finish --slice-only; not add-decision.
+    PLAN FILE (*.plans/<slice-key>.md) = constraint-and-behaviour contract.
+      Long prose lives here.
+    PLAN NOTE (set-plan-note) = destination / high-level map. Not a progress log.
+    PR / REPO (add-pr, set-worktree) = delivery lifecycle. Sync uses finish --note
+      for verify evidence - keep it there.
     Write notes and decisions as Markdown so `pi-job markdown` can render them formatted (decisions as blockquotes; context/notes as Markdown prose or quotes).
     Why: direct inspection loads the whole record into context (token cost); hand-edits bypass validation and orchestration guards.
     Token smell: if a step needs a huge dump to proceed, shrink the contract or the slice; do not dump more of the store into context.
@@ -195,11 +210,18 @@ instruction_packets:
     - Choose an appropriate lower-cost model using judgement.
     - Run this step in a subagent.
     - Give the subagent the prompt below exactly, plus any runtime tool context it needs.
+    - Tell the subagent to run first: pi-job --task {task_file} markdown --slice {slice_key}
+    - Do not paste a decisions dump into the subagent prompt; the markdown --slice read loads binding decisions.
     - Review the subagent result before running pi-job advance.
     - After review, continue the orchestrator loop (finish → advance → instruction); do not wait for "continue".
   subagent_prompt: |-
     This packet is your execution context; do not inspect the task store directly.
-    For sibling-step evidence in this slice, run: pi-job --task {task_file} show --slice {slice_key}
+    Before any other work, run: pi-job --task {task_file} markdown --slice {slice_key}
+    Treat every ## Decisions entry as binding. If SUPERSEDED/RESOLVED, follow the superseding entry.
+    On conflict or a blocking decision, STOP and report - do not re-litigate.
+    New product/scope/architecture/policy decisions only via add-decision.
+    Step evidence (e2e, PR/merge/deploy, WIP/RESOLVED progress) via finish --note / add-pr / plan file - never add-decision.
+    For sibling-step evidence in this slice after decisions are loaded, run: pi-job --task {task_file} show --slice {slice_key}
     Execute only cursor {cursor}.
     Return changed files, commands run, verification evidence, and unresolved risks.
     Do not advance the task record unless this cursor step explicitly asks for task-record updates.
@@ -278,8 +300,9 @@ step_kinds:
       `pi-job --task <this-file> wayfinder-context` to load the map: the destination, recorded
       decisions, and the current frontier/fog of research and fog slices. Take those as given - do not
       re-decide resolved areas. pi-job orchestrates, it does not execute, so spawn as many subagents as
-      needed to reduce uncertainty (research the world, prototype to see, grill the user). Record each
-      resolution as a decision with `add-decision`. Then create whatever slices the chart calls for with
+      needed to reduce uncertainty (research the world, prototype to see, grill the user). Record
+      scope/architecture resolutions with `add-decision`; record research evidence with `finish --note`
+      on the wayfinder step or grow implement/research slices. Then create whatever slices the chart calls for with
       `pi-job add-slice` and the appropriate depends_on: fog slices for areas still too foggy or
       decidable only after other work is done, and implement/research/spike slices for work now clear
       enough to schedule. The pi-job skill's Wayfinder section holds the full map-to-task-file mapping.

--- a/dot_local/share/pi-job-harness/tests/executable_test_pi_job.py
+++ b/dot_local/share/pi-job-harness/tests/executable_test_pi_job.py
@@ -856,6 +856,9 @@ def test_subagent_instruction_prohibits_direct_task_store_inspection() -> None:
         assert_contains(instruction, "Subagent prompt:")
         assert_contains(instruction, "Owner: subagent")
         assert_contains(instruction, "implement-slice / edit-code")
+        assert_contains(instruction, "markdown --slice")
+        assert_contains(instruction, "markdown --slice implement-slice")
+        assert_contains(instruction, "Treat every ## Decisions entry as binding")
         assert_contains(instruction, "show --slice")
         assert_contains(instruction, "show --slice implement-slice")
 
@@ -865,8 +868,10 @@ def test_subagent_instruction_includes_scoped_read_command() -> None:
         task = Path(tmp) / "subagent-scoped-read.yaml"
         task.write_text(subagent_instruction_yaml_task(slice_key="target-slice"), encoding="utf-8")
         instruction = run(str(PI_JOB), "--task", str(task), "instruction", "--current").stdout
+        assert_contains(instruction, "markdown --slice target-slice")
         assert_contains(instruction, "show --slice target-slice")
         assert_not_contains(instruction, "show --slice {slice_key}")
+        assert_not_contains(instruction, "markdown --slice {slice_key}")
 
 
 def test_orchestrator_instruction_has_no_subagent_prompt() -> None:
@@ -877,6 +882,37 @@ def test_orchestrator_instruction_has_no_subagent_prompt() -> None:
         assert_not_contains(instruction, "Subagent prompt:")
         assert_not_contains(instruction, "Read the task file")
         assert_not_contains(instruction, "show --slice")
+        assert_not_contains(instruction, "markdown --slice")
+
+
+def test_subagent_orchestrator_directs_markdown_slice_without_decisions_dump() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        task = Path(tmp) / "subagent-orchestrator-markdown.yaml"
+        task.write_text(subagent_instruction_yaml_task(slice_key="target-slice"), encoding="utf-8")
+        instruction = run(str(PI_JOB), "--task", str(task), "instruction", "--current").stdout
+        assert_contains(instruction, "Orchestrator instruction:")
+        assert_contains(instruction, "markdown --slice target-slice")
+        assert_contains(instruction, "Do not paste a decisions dump")
+        orch_idx = instruction.index("Orchestrator instruction:")
+        prompt_idx = instruction.index("Subagent prompt:")
+        assert orch_idx < prompt_idx, "Orchestrator instruction must precede Subagent prompt"
+
+
+def test_add_decision_and_finish_help_describe_channels() -> None:
+    add_help = run(str(PI_JOB), "add-decision", "--help").stdout
+    finish_help = run(str(PI_JOB), "finish", "--help").stdout
+    assert_contains(add_help, "product/scope decision")
+    assert_contains(add_help, "not step evidence")
+    assert_contains(add_help, "finish --note")
+    assert_contains(finish_help, "not product")
+    assert_contains(finish_help, "add-decision")
+
+
+def test_decision_document_schema_describes_channels_contract() -> None:
+    schema = run(str(PI_JOB), "schema", "--json").stdout
+    assert_contains(schema, "Product, scope, architecture, or policy agreement")
+    assert_contains(schema, "not step evidence")
+    assert_contains(schema, "finish --note")
 
 
 def test_subagent_instruction_still_inlines_step_kind_guidance() -> None:
@@ -940,7 +976,8 @@ def _assert_constraint_and_behaviour_plan_contract(instruction: str) -> None:
         "Do not move delivery status, cursor, or session journals into plan files",
     )
     assert_contains(instruction, "DX and agent experience share the same constructs")
-    assert_contains(instruction, "Persist durable agreements with `pi-job add-decision`")
+    assert_contains(instruction, "Persist product/scope/architecture/policy agreements with `pi-job add-decision`")
+    assert_contains(instruction, "Step evidence belongs in `finish --note`, not `add-decision`")
     assert_contains(instruction, "Token smell:")
     assert_not_contains(instruction, "approach, files/functions touched, key tradeoffs")
 
@@ -964,7 +1001,8 @@ def test_grill_plan_instruction_defines_constraint_and_behaviour_contract() -> N
             "Challenge behaviour, boundaries, must-not constraints, and verification",
         )
         assert_contains(instruction, "prose volume is not an acceptance criterion")
-        assert_contains(instruction, "capture any durable choice that should outlive the session")
+        assert_contains(instruction, "capture product/scope choices that should outlive the session")
+        assert_contains(instruction, "Do not use add-decision for PR, deploy, e2e, or progress chatter")
 
 
 def test_profile_yaml_aliases_shared_guidance_strings() -> None:
@@ -994,6 +1032,10 @@ def _assert_task_record_discipline_block(instruction: str) -> None:
     assert_contains(instruction, "status")
     assert_contains(instruction, "plan")
     assert_contains(instruction, "show")
+    assert_contains(instruction, "markdown")
+    assert_contains(instruction, "Channels (which write for which fact):")
+    assert_contains(instruction, "DECISION (add-decision)")
+    assert_contains(instruction, "STEP NOTE (finish --note)")
     assert_contains(instruction, "instruction")
     assert_contains(instruction, "add-slice")
     assert_contains(instruction, "validation")
@@ -1054,6 +1096,7 @@ def test_task_record_discipline_interpolates_task_file_and_slice_key() -> None:
         task.write_text(subagent_instruction_yaml_task(slice_key="target-slice"), encoding="utf-8")
         instruction = run(str(PI_JOB), "--task", str(task), "instruction", "--current").stdout
         assert_contains(instruction, str(task))
+        assert_contains(instruction, "markdown [--slice target-slice]")
         assert_contains(instruction, "show [--slice target-slice]")
         assert_not_contains(instruction, "{task_file}")
         assert_not_contains(instruction, "{slice_key}")
@@ -6016,6 +6059,12 @@ def main() -> None:
     test_bootstrap_instruction_includes_next_action()
     test_subagent_instruction_includes_task_record_discipline()
     test_task_record_discipline_interpolates_task_file_and_slice_key()
+    test_subagent_instruction_prohibits_direct_task_store_inspection()
+    test_subagent_instruction_includes_scoped_read_command()
+    test_orchestrator_instruction_has_no_subagent_prompt()
+    test_subagent_orchestrator_directs_markdown_slice_without_decisions_dump()
+    test_add_decision_and_finish_help_describe_channels()
+    test_decision_document_schema_describes_channels_contract()
     test_update_task_file_guidance_names_mutation_commands()
     test_plan_output_omits_task_record_discipline()
     test_create_plan_instruction_defines_constraint_and_behaviour_contract()


### PR DESCRIPTION
## Summary
- Subagent packets order `pi-job markdown --slice` before work so agents load binding `## Decisions` with the slice packet; `show --slice` stays as light sibling evidence.
- Add a Channels contract (decision vs `finish --note` vs slice/plan/PR) across profile packets, CLI help, DecisionDocument schema text, README, and the pi-job skill - replacing soft "durable agreements" wording that encouraged evidence in `decisions[]`.
- Tests lock the new phrases; P1 chatter warn / `append-slice-note` deferred.

## Test plan
- [x] `uv run --with pydantic --with pyyaml python tests/executable_test_pi_job.py` in worktree harness
- [x] Smoke: worktree `add-decision --help` / `finish --help` / `schema --json` Channels wording
- [x] Smoke: fresh scaffold+init implement task instruction contains Subagent prompt with `markdown --slice` + Channels
- [ ] chezmoi apply on a machine and dogfood one subagent step against a live task


Made with [Cursor](https://cursor.com)