### PR TITLE
feat(pi-job): finish guards, set-project --title, guidance polish

### DIFF
--- a/dot_local/share/pi-job-harness/README.md
+++ b/dot_local/share/pi-job-harness/README.md
@@ -446,7 +446,7 @@ Every new implement slice includes `vulnerability-scan` after verify and before 
 Acceptance `e2e-evidence` is skippable and runs after `wait-for-feedback`, immediately before `ready-for-release`.
 
 1. The orchestrator asks the user whether the scan is required for that slice.
-2. If accepted, the orchestrator selects a scanner model whose fully qualified ID differs from `edit-code.execution.model`.
+2. If accepted, the orchestrator selects a scanner model whose fully qualified ID differs from `edit-code.execution.model`, and prefers a higher-reasoning / higher-capability model than the code author (not a second fast coding model).
 3. The scanner reviews changed/generated code for vulnerabilities and records findings in the step note.
 4. The step finishes only after findings are resolved or the remaining risk is explicitly accepted.
 5. If the user declines, the orchestrator records `finish --skip --model <id> --reason '<user decision>'`.

--- a/dot_local/share/pi-job-harness/README.md
+++ b/dot_local/share/pi-job-harness/README.md
@@ -383,7 +383,7 @@ Safety guarantees:
 
 These commands write task metadata and durable state without editing the YAML by hand:
 
-- `pi-job --task <t> set-project --key K --name N --route R --context C` - merge into `task.project` (at least one flag required).
+- `pi-job --task <t> set-project --title T --key K --name N --route R --context C` - update `task.title` and/or merge into `task.project` (at least one flag required; `--title` must be non-empty).
 - `pi-job --task <t> set-context --context TEXT` or `--file PATH` - replace `task.context`.
 - `pi-job --task <t> add-decision --date YYYY-MM-DD --note RATIONALE --source ORIGIN` - append a product/scope decision (not step evidence; use `finish --note`; date defaults to today UTC; source defaults to `pi-job add-decision`).
 - `pi-job --task <t> set-plan-note --note TEXT` - set `task.plan.note`.
@@ -434,6 +434,7 @@ execution:
 - `finish --note '<evidence>'` appends completion evidence with a blank line when a note already exists; omitted preserves the existing note.
 - `finish --replace --note '<evidence>'` overwrites the existing note instead of appending (`--replace` requires `--note` and cannot combine with `--skip`).
 - `finish --reconcile --model <id> --note '<evidence>'` records completion for an `in_progress` target that was never started via pi-job; refuses `planned`/`done`/`skipped`.
+- When more than one unfinished step exists anywhere in the task, finishing a step requires explicit `--slice` and `--step` (bare cursor finish is allowed only when exactly one unfinished step remains).
 - Normal `finish` without `--reconcile` still requires a prior `start` (unless `--skip`).
 - `start` refuses `blocked` slices and blocked lifecycle targets; run `unblock-slice` first for slice-level blocks.
 - Existing tasks without execution metadata remain readable; `validate` reports warnings instead of inventing historical data.

--- a/dot_local/share/pi-job-harness/bin/executable_pi-job
+++ b/dot_local/share/pi-job-harness/bin/executable_pi-job
@@ -1118,6 +1118,10 @@ class TaskStore(Protocol):
         """Update task.project fields (merge, not replace)."""
         ...
 
+    def set_title(self, title: str) -> None:
+        """Replace task.title."""
+        ...
+
     def set_context(self, context: str) -> None:
         """Replace task.context."""
         ...
@@ -1228,6 +1232,9 @@ class CueTaskStore:
         write_and_validate(self.path, original_text, "".join(lines))
 
     def set_project(self, fields: Mapping[str, str]) -> None:
+        raise NotImplementedError("CUE task storage is deprecated; migrate to YAML with `pi-job --task <file> project --to <file>.yaml`")
+
+    def set_title(self, title: str) -> None:
         raise NotImplementedError("CUE task storage is deprecated; migrate to YAML with `pi-job --task <file> project --to <file>.yaml`")
 
     def set_context(self, context: str) -> None:
@@ -1903,6 +1910,12 @@ class YamlTaskStore:
 
     def set_project(self, fields: Mapping[str, str]) -> None:
         self._mutate(lambda task: task.setdefault("project", {}).update(fields))
+
+    def set_title(self, title: str) -> None:
+        cleaned = title.strip()
+        if not cleaned:
+            die("title must be non-empty")
+        self._mutate(lambda task: task.update({"title": cleaned}))
 
     def set_context(self, context: str) -> None:
         self._mutate(lambda task: task.update({"context": context}))
@@ -2772,6 +2785,12 @@ class FsTaskStore:
         existing = self._read_record(L.project_file())
         existing.update(fields)
         self._write_record(L.project_file(), existing)
+
+    def set_title(self, title: str) -> None:
+        cleaned = title.strip()
+        if not cleaned:
+            die("title must be non-empty")
+        self._write_text(self.layout.title_file(), cleaned)
 
     def set_context(self, context: str) -> None:
         self._write_text(self.layout.context_file(), context)
@@ -4074,10 +4093,16 @@ def is_fully_qualified_model(model: str) -> bool:
     return "/" in model and not model.startswith("/") and not model.endswith("/")
 
 
+MODEL_ID_EXAMPLE = "openai/gpt-5.6-sol"
+MODEL_ID_QUALIFICATION_HINT = (
+    f"model ID must be fully qualified as provider/model (for example {MODEL_ID_EXAMPLE})"
+)
+
+
 def require_fully_qualified_model(model: str) -> str:
     normalized = model.strip()
     if not is_fully_qualified_model(normalized):
-        die("model ID must be fully qualified as provider/model")
+        die(MODEL_ID_QUALIFICATION_HINT)
     return normalized
 
 
@@ -4128,7 +4153,7 @@ def execution_issues(task: dict[str, Any]) -> list[str]:
             if not model:
                 issues.append(f"{label}: execution.model is empty")
             elif not is_fully_qualified_model(model):
-                issues.append(f"{label}: execution.model is not fully qualified as provider/model")
+                issues.append(f"{label}: execution.model is not fully qualified as provider/model (for example {MODEL_ID_EXAMPLE})")
             if started is None:
                 issues.append(f"{label}: execution.started is not a UTC ISO 8601 timestamp")
             if status in STATUS_DONE and ended is None:
@@ -4138,6 +4163,41 @@ def execution_issues(task: dict[str, Any]) -> list[str]:
             if started is not None and ended is not None and ended < started:
                 issues.append(f"{label}: execution.ended precedes execution.started")
     return issues
+
+
+def unfinished_step_labels(task: dict[str, Any]) -> list[str]:
+    """Return `slice/step` labels for every step not done/skipped, across the task."""
+    labels: list[str] = []
+    for task_slice in task_slices(task):
+        for step in task_slice.all_steps:
+            if step.status not in STATUS_DONE:
+                labels.append(f"{task_slice.key}/{step.key}")
+    return labels
+
+
+def enforce_finish_step_explicitness(
+    task: dict[str, Any], args: argparse.Namespace, *, step_key: str | None
+) -> None:
+    """Fail closed when bare finish could attach evidence to the wrong step.
+
+    Grill rule: when more than one unfinished step exists anywhere, finishing a
+    step requires explicit --slice and --step. Bare finish (cursor defaults) is
+    allowed only when exactly one unfinished step remains. Slice-only finishes
+    are exempt (they already refuse unfinished steps inside the target slice).
+    """
+    if step_key is None:
+        return
+    if args.slice and args.step:
+        return
+    unfinished = unfinished_step_labels(task)
+    if len(unfinished) <= 1:
+        return
+    sample = ", ".join(unfinished[:5])
+    extra = "" if len(unfinished) <= 5 else f" (+{len(unfinished) - 5} more)"
+    die(
+        f"finish target ambiguous: {len(unfinished)} unfinished steps "
+        f"({sample}{extra}); pass --slice KEY --step KEY"
+    )
 
 
 def resolve_lifecycle_target(
@@ -4195,7 +4255,7 @@ def step_policy_issue(
     if not author_model:
         return f"{source_step_key} has no recorded execution.model; record the code-author model before scanning"
     if not is_fully_qualified_model(author_model):
-        return f"{source_step_key} execution.model is not fully qualified as provider/model"
+        return f"{source_step_key} execution.model is not fully qualified as provider/model (for example {MODEL_ID_EXAMPLE})"
     if model == author_model:
         return (
             f"{step_key} model must differ from {source_step_key} model "
@@ -4215,7 +4275,7 @@ def completed_step_policy_issue(task_slice: TaskSlice, step: TaskStep) -> str | 
     if not execution or not model or not execution.started or not execution.ended:
         return f"{step.key} requires model, started, and ended execution metadata"
     if not is_fully_qualified_model(model):
-        return f"{step.key} execution.model must be fully qualified as provider/model"
+        return f"{step.key} execution.model must be fully qualified as provider/model (for example {MODEL_ID_EXAMPLE})"
     started = parse_utc_timestamp(execution.started)
     ended = parse_utc_timestamp(execution.ended)
     if started is None or ended is None:
@@ -4284,6 +4344,7 @@ def cmd_finish(args: argparse.Namespace) -> None:
         task = store.read()
         require_initialized(task_file, task)
         task_slice, item, step_key = resolve_lifecycle_target(task, args)
+        enforce_finish_step_explicitness(task, args, step_key=step_key)
         label = f"{task_slice.key}/{step_key}" if step_key else task_slice.key
         target_status = "skipped" if args.skip else "done"
         existing = item.execution
@@ -6924,11 +6985,20 @@ def cmd_set_project(args: argparse.Namespace) -> None:
         value = getattr(args, attr, None)
         if value is not None:
             fields[attr] = value
-    if not fields:
-        die("at least one project field is required (--key, --name, --route, --context)")
+    title = getattr(args, "title", None)
+    if title is not None and not str(title).strip():
+        die("title must be non-empty")
+    if not fields and title is None:
+        die("at least one field is required (--title, --key, --name, --route, --context)")
     store = open_task_store(task_file)
-    store.set_project(fields)
-    print(f"updated project: {', '.join(f'{k}={v}' for k, v in fields.items())}")
+    updated: list[str] = []
+    if title is not None:
+        store.set_title(str(title).strip())
+        updated.append(f"title={str(title).strip()}")
+    if fields:
+        store.set_project(fields)
+        updated.extend(f"{k}={v}" for k, v in fields.items())
+    print(f"updated: {', '.join(updated)}")
 
 
 def cmd_set_context(args: argparse.Namespace) -> None:
@@ -7423,7 +7493,8 @@ def main() -> None:
     add_slice.add_argument("--dry-run", action="store_true")
     add_slice.set_defaults(fn=cmd_add_slice)
 
-    set_project = sub.add_parser("set-project", help="update task project fields (merge into existing)")
+    set_project = sub.add_parser("set-project", help="update task title and/or project fields (merge into existing project)")
+    set_project.add_argument("--title", help="task.title (non-empty)")
     set_project.add_argument("--key", help="project key")
     set_project.add_argument("--name", help="project name")
     set_project.add_argument("--route", help="project route path")

--- a/dot_local/share/pi-job-harness/bin/executable_pi-job
+++ b/dot_local/share/pi-job-harness/bin/executable_pi-job
@@ -4813,6 +4813,8 @@ def build_instruction(task_file: Path, task: dict[str, Any], cursor: Cursor) -> 
             lines += [
                 f"- Model recorded on {source_step_key}: {source_model}",
                 "- Choose a different fully qualified model ID for this step.",
+                "- Prefer a higher-reasoning / higher-capability model than that author model "
+                "(do not reuse a fast coding or low-cost edit model for review/scan).",
             ]
         lines.append("- Record the outcome and resolve findings or explicitly record accepted risk before advancing.")
 

--- a/dot_local/share/pi-job-harness/profile.yaml
+++ b/dot_local/share/pi-job-harness/profile.yaml
@@ -244,12 +244,14 @@ instruction_packets:
     - Do not skip required artifacts or validators from the task contract.
     - Run pi-job advance only after the step evidence is recorded or a blocker is written down.
   subagent_orchestrator: |-
-    - Choose an appropriate lower-cost model using judgement.
+    - Choose an appropriate lower-cost model using judgement for the coding/subagent pass.
     - Run this step in a subagent.
     - Give the subagent the prompt below exactly, plus any runtime tool context it needs.
     - Tell the subagent to run first: pi-job --task TASK_FILE markdown --slice SLICE_KEY --with-decisions
     - Do not paste a decisions dump into the subagent prompt; the markdown --slice --with-decisions read loads binding decisions.
     - Review the subagent result before running pi-job advance.
+      Prefer a higher-reasoning model for that review pass than the subagent used to write
+      the change (spot incorrect assumptions, missed edge cases, and unsafe defaults).
     - After review, continue the orchestrator loop (finish → advance → instruction); do not wait for "continue".
   subagent_prompt: |-
     This packet is your execution context; do not inspect the task store directly.
@@ -462,7 +464,21 @@ step_kinds:
       - scanner-model-differs-from-code-author-model
       - vulnerabilities-resolved-or-risk-accepted
     skip_rule: only when the user explicitly declines the scan for this implement slice
-    guidance: Ask the user whether this implement slice requires a vulnerability scan. If declined, record an explicit user-declined skip. If accepted, dispatch a vulnerability-focused reviewer whose fully qualified model ID differs from the model recorded on edit-code, regardless of whether edit-code ran in the orchestrator or a subagent. Record findings and ensure they are resolved or explicitly accepted before sharing.
+    guidance: |-
+      Ask the user whether this implement slice requires a vulnerability scan.
+      If declined, record an explicit user-declined skip.
+      If accepted, dispatch a vulnerability-focused reviewer as a separate pass:
+      - Fully qualified model ID must differ from the model recorded on edit-code
+        (whether edit-code ran in the orchestrator or a subagent).
+      - Prefer a higher-reasoning / higher-capability model than the code author
+        (do not reuse a fast coding or low-cost edit model for the scan).
+        Example pattern: if edit-code used a composer/fast ID, pick a reasoning-oriented
+        ID from a different family or a stronger tier in the same provider.
+      - Review the changed/generated code for vulnerabilities, insecure defaults,
+        authz gaps, injection, secrets, and unsafe trust boundaries.
+      - Record findings in finish --note; resolve them or explicitly accept remaining
+        risk before sharing.
+      Do not treat "different model" alone as enough - capability for review matters.
   share-with-team:
     key: share-with-team
     title: 'Share with team: ticket + PR for this slice''s repo'

--- a/dot_local/share/pi-job-harness/profile.yaml
+++ b/dot_local/share/pi-job-harness/profile.yaml
@@ -114,6 +114,10 @@ pr_template_guardrail: &pr_template_guidance |-
   PR description: Vocabulary, How <feature> works, What this PR adds, quirks,
   Errors, Known limitation, Tests) - do not freehand a bespoke PR body in either
   case.
+  After opening the PR, record it:
+    pi-job --task TASK_FILE add-pr --slice SLICE_KEY --repo REPO --url URL --status open
+  Prefer `gh pr create --head <branch>` right after the first push of a new branch
+  (avoids the "must first push" abort).
 plan_and_grill_guardrail: &plan_and_grill_guidance |-
   Before any other step in an implement/spike slice starts, that slice's steps must
   begin with exactly two leading steps, in order:
@@ -170,12 +174,18 @@ sync_pipeline_instructions: |-
 cli_help:
   add_decision:
     command: append a product/scope decision (not step evidence; use finish --note)
-    note: decision rationale as Markdown (preferred); rendered as a blockquote in `pi-job markdown`
+    note: >-
+      decision rationale as Markdown (preferred); rendered as a blockquote in `pi-job markdown`.
+      Shell-safe: pass --note with single quotes or a HEREDOC; bare backticks in double-quoted
+      shell args are command-substituted (example: --note 'Keep expiresAt as-is').
   finish:
     note: >-
       append completion/evidence for this step (not product decisions; use add-decision);
       Markdown preferred; rendered formatted in `pi-job markdown`; omitted preserves the
-      existing note; when supplied appends with a blank line; --replace overwrites instead
+      existing note; when supplied appends with a blank line; --replace overwrites instead.
+      Shell-safe: pass --note with single quotes or a HEREDOC so backticks/paths are not
+      executed by the shell (example: finish --note 'Ran yarn test in worktree').
+      When more than one unfinished step exists, pass --slice KEY --step KEY.
 instruction_packets:
   todo_tracking: |-
     - Keep session todos aligned with `pi-job plan` for this task.
@@ -478,7 +488,12 @@ step_kinds:
     owner: orchestrator
     validators:
       - feedback-window-recorded
-    guidance: Not terminal until the PR merges or is explicitly abandoned. Re-check via `pi-job sync`.
+    guidance: |-
+      Not terminal until the PR merges or is explicitly abandoned.
+      Re-check via `pi-job sync` (store-side) then live `gh pr view`.
+      When the user reports a merge (or gh shows MERGED), record it before finish:
+        pi-job --task TASK_FILE add-pr --slice SLICE_KEY --repo REPO --url URL --status merged
+      Then finish --note with the merge evidence and advance.
   update-task-file:
     key: update-task-file
     title: Update this task file

--- a/dot_local/share/pi-job-harness/tests/executable_test_pi_job.py
+++ b/dot_local/share/pi-job-harness/tests/executable_test_pi_job.py
@@ -5189,6 +5189,18 @@ def test_vulnerability_scan_rejects_writer_model() -> None:
         assert_contains(result.stderr, "must differ from edit-code model")
 
 
+def test_vulnerability_scan_instruction_prefers_higher_reasoning_model() -> None:
+    """Scan packets must recommend a stronger review model, not only a different ID."""
+    with tempfile.TemporaryDirectory() as tmp:
+        task = Path(tmp) / "scan-instruction.yaml"
+        write_task_yaml(task, lifecycle_mapping())
+        instruction = run(str(PI_JOB), "--task", str(task), "instruction").stdout
+        assert_contains(instruction, "vulnerability-scan")
+        assert_contains(instruction, "higher-reasoning")
+        assert_contains(instruction, "Model recorded on edit-code")
+        assert_contains(instruction, "anthropic/claude-writer")
+
+
 def test_vulnerability_scan_rejects_unqualified_author_model() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         task = Path(tmp) / "unqualified-author.yaml"
@@ -6863,6 +6875,7 @@ def main() -> None:
     test_unblock_slice_refuses_non_blocked()
     test_start_refuses_blocked_slice()
     test_vulnerability_scan_rejects_writer_model()
+    test_vulnerability_scan_instruction_prefers_higher_reasoning_model()
     test_vulnerability_scan_rejects_unqualified_author_model()
     test_start_unqualified_model_error_includes_example()
     test_advance_rejects_malformed_scan_timestamps()

--- a/dot_local/share/pi-job-harness/tests/executable_test_pi_job.py
+++ b/dot_local/share/pi-job-harness/tests/executable_test_pi_job.py
@@ -4997,6 +4997,59 @@ def test_finish_replace_refused_with_skip() -> None:
         assert_contains(res.stderr, "finish --replace cannot be combined with --skip")
 
 
+def test_finish_bare_refuses_when_multiple_unfinished_steps() -> None:
+    """When ≥2 unfinished steps exist, bare finish (cursor defaults) fails closed."""
+    with tempfile.TemporaryDirectory() as tmp:
+        task = Path(tmp) / "finish-ambiguous.yaml"
+        mapping = standard_fixture_mapping(cursor=("second-slice", "s2"))
+        write_task_yaml(task, mapping)
+        run(str(PI_JOB), "--task", str(task), "start", "--model", "openai/gpt-orchestrator")
+        res = run(
+            str(PI_JOB), "--task", str(task), "finish",
+            "--note", "Should refuse - other unfinished steps exist.",
+            check=False,
+        )
+        if res.returncode == 0:
+            raise AssertionError("bare finish with multiple unfinished steps unexpectedly succeeded")
+        assert_contains(res.stderr, "finish target ambiguous")
+        assert_contains(res.stderr, "--slice KEY --step KEY")
+
+
+def test_finish_explicit_slice_step_ok_when_multiple_unfinished() -> None:
+    """Explicit --slice/--step succeeds even when other unfinished steps remain."""
+    with tempfile.TemporaryDirectory() as tmp:
+        task = Path(tmp) / "finish-explicit.yaml"
+        mapping = standard_fixture_mapping(cursor=("second-slice", "s2"))
+        write_task_yaml(task, mapping)
+        run(
+            str(PI_JOB), "--task", str(task), "start",
+            "--slice", "second-slice", "--step", "s2",
+            "--model", "openai/gpt-orchestrator",
+        )
+        out = run(
+            str(PI_JOB), "--task", str(task), "finish",
+            "--slice", "second-slice", "--step", "s2",
+            "--note", "Evidence on the named step.",
+        ).stdout
+        assert_contains(out, "finished: second-slice/s2")
+        module = load_pi_job_module()
+        step = find_step(module.YamlTaskStore(task).read(), "second-slice", "s2")
+        assert step["status"] == "done"
+
+
+def test_finish_bare_ok_when_exactly_one_unfinished_step() -> None:
+    """Bare finish remains allowed when the task has only one unfinished step."""
+    with tempfile.TemporaryDirectory() as tmp:
+        task = Path(tmp) / "finish-single.yaml"
+        write_task_yaml(task, lifecycle_mapping())
+        run(str(PI_JOB), "--task", str(task), "start", "--model", "google/gemini-reviewer")
+        out = run(
+            str(PI_JOB), "--task", str(task), "finish",
+            "--note", "Only one unfinished step.",
+        ).stdout
+        assert_contains(out, "finished: implementation/vulnerability-scan")
+
+
 def test_set_slice_updates_title_and_goal() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         task = Path(tmp) / "set-slice.yaml"
@@ -5148,6 +5201,25 @@ def test_vulnerability_scan_rejects_unqualified_author_model() -> None:
         )
         assert result.returncode != 0
         assert_contains(result.stderr, "not fully qualified as provider/model")
+        assert_contains(result.stderr, "openai/gpt-5.6-sol")
+
+
+def test_start_unqualified_model_error_includes_example() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        task = Path(tmp) / "unqualified-start.yaml"
+        write_task_yaml(task, lifecycle_mapping())
+        # Neutralize different-model policy by using a planned non-scan step fixture:
+        # lifecycle cursor is vulnerability-scan; skip that by finishing via bare single-step path
+        # after first making author model qualified - use create empty instead.
+        run(str(PI_JOB), "--task", str(task), "create", "--kind", "implement", "--force", "--title", "Model id")
+        res = run(
+            str(PI_JOB), "--task", str(task), "start", "--model", "composer-2",
+            check=False,
+        )
+        if res.returncode == 0:
+            raise AssertionError("unqualified start model unexpectedly succeeded")
+        assert_contains(res.stderr, "fully qualified as provider/model")
+        assert_contains(res.stderr, "openai/gpt-5.6-sol")
 
 
 def test_advance_rejects_malformed_scan_timestamps() -> None:
@@ -5500,6 +5572,30 @@ def test_set_project_mutation() -> None:
         task_data = store.read()
         assert task_data["project"]["key"] == "new-key"
         assert task_data["project"]["name"] == "New Name"
+
+
+def test_set_project_title_updates_task_title() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        task = Path(tmp) / "project-title.yaml"
+        run(str(PI_JOB), "--task", str(task), "create", "--empty-plan", "--force", "--title", "Old title")
+        out = run(
+            str(PI_JOB), "--task", str(task), "set-project", "--title", "Widened scope title",
+        ).stdout
+        assert_contains(out, "title=Widened scope title")
+        module = load_pi_job_module()
+        assert module.YamlTaskStore(task).read()["title"] == "Widened scope title"
+        status = run(str(PI_JOB), "--task", str(task), "status").stdout
+        assert_contains(status, "Widened scope title")
+
+
+def test_set_project_title_refuses_empty() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        task = Path(tmp) / "project-title-empty.yaml"
+        run(str(PI_JOB), "--task", str(task), "create", "--empty-plan", "--force")
+        res = run(str(PI_JOB), "--task", str(task), "set-project", "--title", "   ", check=False)
+        if res.returncode == 0:
+            raise AssertionError("empty set-project --title unexpectedly succeeded")
+        assert_contains(res.stderr, "title must be non-empty")
 
 
 def test_set_context_mutation() -> None:
@@ -6755,6 +6851,9 @@ def main() -> None:
     test_finish_replace_requires_note()
     test_finish_note_append_with_slice_only()
     test_finish_replace_refused_with_skip()
+    test_finish_bare_refuses_when_multiple_unfinished_steps()
+    test_finish_explicit_slice_step_ok_when_multiple_unfinished()
+    test_finish_bare_ok_when_exactly_one_unfinished_step()
     test_set_slice_updates_title_and_goal()
     test_set_slice_requires_one_field()
     test_set_slice_refuses_done_slice()
@@ -6765,6 +6864,7 @@ def main() -> None:
     test_start_refuses_blocked_slice()
     test_vulnerability_scan_rejects_writer_model()
     test_vulnerability_scan_rejects_unqualified_author_model()
+    test_start_unqualified_model_error_includes_example()
     test_advance_rejects_malformed_scan_timestamps()
     test_vulnerability_scan_can_record_user_declined_skip()
     test_slice_lifecycle_records_orchestrator_after_steps_finish()
@@ -6791,6 +6891,8 @@ def main() -> None:
     test_add_slice_follow_work_seeds_template_steps()
     test_validate_accepts_conformant_follow_work_fixture()
     test_set_project_mutation()
+    test_set_project_title_updates_task_title()
+    test_set_project_title_refuses_empty()
     test_set_context_mutation()
     test_add_decision_mutation()
     test_set_plan_note_mutation()


### PR DESCRIPTION
## Summary
- Fail closed on bare `finish` when more than one unfinished step exists; require `--slice`/`--step`
- Add `set-project --title` for `task.title` (non-empty)
- Model-ID qualification errors include an example (`openai/gpt-5.6-sol`)
- Share/wait/note guidance: shell-safe `--note`, `add-pr` examples, merge checklist

## Test plan
- [x] New unit tests for finish ambiguity, set-project --title, model-ID example
- [x] Full `tests/executable_test_pi_job.py` suite green
- [ ] `chezmoi apply ~/.local/share/pi-job-harness` after merge


Made with [Cursor](https://cursor.com)